### PR TITLE
Add without wrapping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ protected $allow_mode_switch = true;
 protected $allow_multiple = true;
 
 protected $parent = [];
+
+protected $inner_blocks = false;
+
+protected $wrap = true;
 ```
 
 ## Register blocks
@@ -108,7 +112,6 @@ class ChildBlock extends Block
 ```
 
 > For the child block to be selectable within the parent block you will need to set `$inner_blocks = true` on the parent block.
-
 
 ## Configure fields
 
@@ -155,22 +158,23 @@ $body = $this->get('body', 'Hello world!');
 
 By default a few classes are added to the wrapper HTML-element to be able to add general styles and specific styles for blocks and respect the alignment and other input from the Gutenberg editor.
 
-You can override or extend the classes that are added by defining your own `classes` method:
+You can simply fetch the CSS-classes using `getClasses()`.  
+To override or extend the classes that are added by defining your own `setClasses()`:
 
 ```php
 // Override the default classes
-protected function classes($block)
+protected function setClasses($block)
 {
     return [
-        'my-custom-css-class'
-        //...
-    ];
+        'my-custom-css-class',
+        //
+    ]);
 }
 
 // Extend the default classes
-protected function classes($block)
+protected function setClasses($block)
 {
-    return array_merge(parent::classes($block), [
+    return array_merge(parent::setClasses($block), [
         'my-custom-css-class',
     ]);
 }
@@ -214,6 +218,23 @@ class MyCustomBlock extends Block
 }
 
 ```
+
+### Wrapper Element
+
+By default every block is wrapped in a `<div>` with the default classes when rendered. You can disable this globally by calling `Gutenberg::withoutWrapping()` **before** registering blocks.
+
+When wrapping is disabled and you want to add the default CSS-classes in your own template you can add them like so:
+
+```php
+public function render()
+{
+    // Make the CSS-classes available as a variable in the template
+    set_query_var('default_classes', $this->getClasses());
+
+    return get_template_part('path-to-my-block-template');
+}
+```
+
 
 ## License
 

--- a/src/Block.php
+++ b/src/Block.php
@@ -32,6 +32,10 @@ abstract class Block
 
     protected $inner_blocks = false;
 
+    protected $wrap = true;
+
+    private $classes = [];
+
     abstract public function render();
 
     public function fields()
@@ -87,21 +91,45 @@ abstract class Block
                 'jsx' => $this->inner_blocks,
             ],
             'render_callback' => function ($block) {
-                echo '<div class="'. trim(implode(' ', $this->classes($block))) .'">';
+                $this->setClasses($block);
+
+                if ($this->wrappingEnabled()) {
+                    echo '<div class="'. trim(implode(' ', $this->getClasses())) .'">';
+                }
+
                 echo $this->render()->toHtml() ?? $this->render();
-                echo '</div>';
+
+                if ($this->wrappingEnabled()) {
+                    echo '</div>';
+                }
             },
         ]);
     }
 
-    protected function classes($block)
+    protected function setClasses($block)
     {
-        return [
+        $classes = array_merge($this->classes, [
             'wp-blocks-block',
             'wp-block-' .$this->name,
             $block['className'] ?? '',
             $block['align'] ? 'align' . $block['align'] : '',
-        ];
+        ]);
+
+        $this->classes = array_filter($classes);
+    }
+
+    protected function getClasses()
+    {
+        return $this->classes;
+    }
+
+    private function wrappingEnabled()
+    {
+        if (!Gutenberg::$wrapping) {
+            return false;
+        }
+
+        return $this->wrap;
     }
 
     private function register()

--- a/src/Gutenberg.php
+++ b/src/Gutenberg.php
@@ -6,6 +6,8 @@ use Illuminate\Filesystem\Filesystem;
 
 class Gutenberg
 {
+    public static $wrapping = true;
+
     public static function register($blocksOrPath)
     {
         $blocks = [];
@@ -30,5 +32,10 @@ class Gutenberg
         foreach ($blocks as $block) {
             new $block();
         }
+    }
+
+    public static function withoutWrapping()
+    {
+        self::$wrapping = false;
     }
 }


### PR DESCRIPTION
Adds the option to enable or disable the wrapper element globally or per block.

Disable globally:

```php
Gutenberg::withoutWrapping();
```

Disable on a block:
```php

class MyBlock extends Block
{
    $wrap = false;
}
```

This change also affects the CSS-classes feature.  
You can manage the classes or alter them using the following functions:

```php

protected function setClasses($block)
{
    //...
}

protected function getClasses()
{
    //...
}
```